### PR TITLE
feat: Configure paper trading portfolio backups to save in Reports Da…

### DIFF
--- a/PORTFOLIO_BACKUP_UPDATE.md
+++ b/PORTFOLIO_BACKUP_UPDATE.md
@@ -1,0 +1,55 @@
+# Portfolio Backup Configuration Update
+
+## Summary
+Modified the paper trading system to automatically save all `paper_trading_portfolio_*.json.bak` backup files to the "Reports Day Trading" folder instead of cluttering the main project directory.
+
+## Changes Made
+
+### 1. Modified `paper_trading.py`
+- **File**: `c:\Users\shaik\OneDrive\Algo_Trader 25_10_2025\algotrader-backend\paper_trading.py`
+- **Method**: `_save_portfolio_state()` (lines 564-573)
+- **Change**: Updated backup file path to save in "Reports Day Trading" folder
+
+**Before:**
+```python
+backup = self.portfolio_file.with_name(f"paper_trading_portfolio_{ts}.json.bak")
+```
+
+**After:**
+```python
+# Save backup files to Reports Day Trading folder
+reports_dir = Path('Reports Day Trading')
+reports_dir.mkdir(exist_ok=True)  # Ensure directory exists
+backup = reports_dir / f"paper_trading_portfolio_{ts}.json.bak"
+```
+
+### 2. Moved Existing Files
+- Moved 108 existing `paper_trading_portfolio_*.json.bak` files from the main directory to the "Reports Day Trading" folder
+- Used PowerShell command: `Move-Item -Path "paper_trading_portfolio_*.json.bak" -Destination "Reports Day Trading\"`
+
+## Benefits
+
+1. **Cleaner Directory Structure**: Main project directory is no longer cluttered with backup files
+2. **Organized Reports**: All trading portfolio backups are now in a dedicated folder
+3. **Automatic Folder Creation**: The system automatically creates the "Reports Day Trading" folder if it doesn't exist
+4. **Backward Compatibility**: Main portfolio file (`paper_trading_portfolio.json`) remains in the root directory for easy access by other components
+
+## Testing
+
+Created and ran `test_portfolio_backup.py` which confirms:
+- ✅ Reports Day Trading folder is created automatically
+- ✅ Backup files are saved to the correct location
+- ✅ File naming convention remains the same
+- ✅ No impact on main portfolio file location
+
+## Impact
+
+- **Zero Breaking Changes**: Main portfolio file location unchanged
+- **Dashboard/API Compatibility**: No changes needed for web dashboard or API endpoints
+- **Future Backups**: All new backup files will automatically go to the Reports Day Trading folder
+
+## Date
+October 25, 2025
+
+## Status
+✅ **COMPLETED** - All paper trading portfolio backup files now save to "Reports Day Trading" folder

--- a/paper_trading.py
+++ b/paper_trading.py
@@ -565,7 +565,10 @@ class PerfectTraderPaperTrading:
             try:
                 if self.portfolio_file.exists():
                     ts = datetime.now(IST).strftime('%Y%m%d_%H%M%S')
-                    backup = self.portfolio_file.with_name(f"paper_trading_portfolio_{ts}.json.bak")
+                    # Save backup files to Reports Day Trading folder
+                    reports_dir = Path('Reports Day Trading')
+                    reports_dir.mkdir(exist_ok=True)  # Ensure directory exists
+                    backup = reports_dir / f"paper_trading_portfolio_{ts}.json.bak"
                     backup.write_text(self.portfolio_file.read_text(encoding='utf-8'), encoding='utf-8')
             except Exception:
                 pass


### PR DESCRIPTION
…y Trading folder

- Modified _save_portfolio_state() method in paper_trading.py to save backup files in 'Reports Day Trading' folder
- Moved 108 existing paper_trading_portfolio_*.json.bak files to Reports Day Trading folder
- Added automatic folder creation with mkdir(exist_ok=True)
- Maintains backward compatibility - main portfolio file stays in root directory
- Added documentation in PORTFOLIO_BACKUP_UPDATE.md
- Tested functionality - all future backups will save to dedicated folder